### PR TITLE
Update xpath.js dependency to approximately current stable version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "request": ">= 2.9.203",
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
-    "xpath.js": "0.0.3"
+    "xpath.js": "~1.0.5"
   },
   "devDependencies": {
     "async": "*",


### PR DESCRIPTION
All the tests pass on the current version, so I don't any reason to cling to an older version.
