### PR TITLE
Update xpath.js dependency to approximately current stable version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "request": ">= 2.9.203",
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
-    "xpath.js": "0.0.3"
+    "xpath.js": "~1.0.5"
   },
   "devDependencies": {
     "async": "*",


### PR DESCRIPTION
All the tests pass on the current version, so I don't any reason to cling
to an older version.

Commit to dev branch, re: https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/pull/17#issuecomment-60683469
