### PR TITLE
The authority passed to instance discovery should be the full authorize endpoint.

### DIFF
--- a/lib/authority.js
+++ b/lib/authority.js
@@ -77,9 +77,6 @@ Object.defineProperty(Authority.prototype, 'tokenEndpoint', {
   }
 });
 
-// This is fallback metadata in case the discovery endpoint is not available.
-Authority.AAD_METADATA = '{"version":"1","instances":[{"id":"https://login.windows.net","endpoints":[{"location":"https://login.windows.net/{tenant}/oauth2/authorize","usage":"Auth20Authorize"},{"location":"https://login.windows.net/{tenant}/oauth2/token","usage":"Auth20Token"}]}]}';
-
 /**
  * Checks the authority url to ensure that it meets basic requirements such as being over SSL.  If it does not then
  * this method will throw if any of the checks fail.
@@ -131,7 +128,7 @@ Authority.prototype._performStaticInstanceDiscovery = function() {
 };
 
 Authority.prototype._createAuthorityUrl = function() {
-  return 'https://' + this._url.host + '/' + this._tenant;
+  return 'https://' + this._url.host + '/' + this._tenant + AADConstants.AUTHORIZE_ENDPOINT_PATH;
 };
 
 /**

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -114,8 +114,9 @@ var Constants = {
 
     AADConstants : {
       WORLD_WIDE_AUTHORITY : 'login.windows.net',
-      WELL_KNOWN_AUTHORITY_HOSTS : ['login.windows.net', 'login.chinacloudapi.cn', 'login.cloudgovapi.us'],
+      WELL_KNOWN_AUTHORITY_HOSTS : ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login.cloudgovapi.us'],
       INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE : 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0',
+      AUTHORIZE_ENDPOINT_PATH : '/oauth2/authorize',
       TOKEN_ENDPOINT_PATH : '/oauth2/token'
     },
 


### PR DESCRIPTION
The authority passed to instance discovery should be the full authorize endpoint, ending with /oauth2/authorize, rather than stopping at the tenant name.  Also adds login.microsoftonline.com to the list of whitelisted authorities.  Fixes:

#35

https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues