### PR TITLE
ensure the min version of async which contains .retry support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
     "xpath.js": "~1.0.5", 
-	"async": "*"
+    "async": ">=0.6.0"
   },
   "devDependencies": {
     "jshint": "*",


### PR DESCRIPTION
The ".retry" didn't come out till 0.6.0, so get the dependency right to avoid debugging effort if the client still stays with lower versions