### PR TITLE
Dev mega refresh token

### DIFF
--- a/lib/authentication-context.js
+++ b/lib/authentication-context.js
@@ -142,12 +142,6 @@ Object.defineProperty(AuthenticationContext.prototype, 'options', {
   }
 });
 
-Object.defineProperty(AuthenticationContext.prototype, 'extraQP', {
-  set: function (value) {
-    this._callContext.extraQP = value;
-  }  
-});
-
 /**
  * Get the token cache used by this AuthenticationContext instance.
  * @instance

--- a/lib/authentication-context.js
+++ b/lib/authentication-context.js
@@ -142,6 +142,12 @@ Object.defineProperty(AuthenticationContext.prototype, 'options', {
   }
 });
 
+Object.defineProperty(AuthenticationContext.prototype, 'extraQP', {
+  set: function (value) {
+    this._callContext.extraQP = value;
+  }  
+});
+
 /**
  * Get the token cache used by this AuthenticationContext instance.
  * @instance
@@ -400,7 +406,9 @@ AuthenticationContext.prototype.acquireUserCode = function(resource, clientId, l
 };
 
 /**
- * Gets a new access token using via a device code. 
+ * Gets a new access token using via a device code.
+ * @note This method doesn't look up the cache, it only stores the returned token into cache. To look up cache before making a new request, 
+ *       please use acquireToken.  
  * @param  {string}   clientId                            The OAuth client id of the calling application.
  * @param  {object}   userCodeInfo                        Contains device_code, retry interval, and expire time for the request for get the token. 
  * @param  {AcquireTokenCallback}   callback              The callback function.
@@ -418,7 +426,7 @@ AuthenticationContext.prototype.acquireTokenWithDeviceCode = function(resource, 
     var self = this;
     this._acquireToken(callback, function() {
         var tokenRequest = new TokenRequest(this._callContext, this, clientId, resource, null);
-        self._tokenRequestWithUserCode[userCodeInfo[constants.OAuth2.DeviceCodeResponseParameters.DEVICE_CODE]] = tokenRequest;
+        self._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]] = tokenRequest;
         tokenRequest.getTokenWithDeviceCode(userCodeInfo, callback); 
     })
 };
@@ -438,15 +446,15 @@ AuthenticationContext.prototype.cancelRequestToGetTokenWithDeviceCode = function
        return;
     }
 
-    if (!this._tokenRequestWithUserCode || !this._tokenRequestWithUserCode[userCodeInfo[constants.OAuth2.DeviceCodeResponseParameters.DEVICE_CODE]]) {
+    if (!this._tokenRequestWithUserCode || !this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]]) {
        callback(new Error('No acquireTokenWithDeviceCodeRequest existed to be cancelled')); 
        return;
     }
 
-    var tokenRequestToBeCancelled = this._tokenRequestWithUserCode[userCodeInfo[constants.OAuth2.DeviceCodeResponseParameters.DEVICE_CODE]];
+    var tokenRequestToBeCancelled = this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]];
     tokenRequestToBeCancelled.cancelTokenRequestWithDeviceCode();
 
-    delete this._tokenRequestWithUserCode[constants.OAuth2.DeviceCodeResponseParameters.DEVICE_CODE];
+    delete this._tokenRequestWithUserCode[constants.UserCodeResponseFields.DEVICE_CODE];
 };
 
 var exports = {

--- a/lib/cache-driver.js
+++ b/lib/cache-driver.js
@@ -137,10 +137,6 @@ function CacheDriver(callContext, authority, resource, clientId, cache, refreshF
  * @param  {QueryCallback} callback
  */
 CacheDriver.prototype._find = function(query, callback) {
-  var authorityQuery = {};
-  authorityQuery[METADATA_AUTHORITY] = this._authority;
-
-  _.extend(query, authorityQuery);
   this._cache.find(query, callback);
 };
 
@@ -171,10 +167,11 @@ CacheDriver.prototype._getPotentialEntries = function(query, callback) {
 
 /**
  * Finds all multi resource refresh tokens in the cache.
+ * Refresh token is bound to userId, clientId. 
  * @param  {QueryCallback} callback
  */
 CacheDriver.prototype._findMRRTTokensForUser = function(user, callback) {
-  this._find({ isMRRT : true, userId : user }, callback);
+  this._find({ isMRRT : true, userId : user, _clientId : this._clientId}, callback);
 };
 
 /**
@@ -201,13 +198,12 @@ CacheDriver.prototype._loadSingleEntryFromCache = function(query, callback) {
     }
 
     var returnVal;
-    var isResourceSpecific;
+    var isResourceTenantSpecific;
 
     if (potentialEntries && 0 < potentialEntries.length) {
-      var resourceSpecificEntries;
-      resourceSpecificEntries = _.where(potentialEntries, { resource : self._resource });
+      var resourceTenantSpecificEntries = _.where(potentialEntries, { resource : self._resource, _authority : self._authority });
 
-      if (!resourceSpecificEntries || 0 === resourceSpecificEntries.length) {
+      if (!resourceTenantSpecificEntries || 0 === resourceTenantSpecificEntries.length) {
         self._log.verbose('No resource specific cache entries found.');
 
         // There are no resource specific entries.  Find an MRRT token.
@@ -219,10 +215,10 @@ CacheDriver.prototype._loadSingleEntryFromCache = function(query, callback) {
           self._log.verbose('No MRRT tokens found.');
         }
 
-      } else if (resourceSpecificEntries.length === 1) {
+      } else if (resourceTenantSpecificEntries.length === 1) {
         self._log.verbose('Resource specific token found.');
-        returnVal = resourceSpecificEntries[0];
-        isResourceSpecific = true;
+        returnVal = resourceTenantSpecificEntries[0];
+        isResourceTenantSpecific = true;
       }else {
         callback(self._log.createError('More than one token matches the criteria.  The result is ambiguous.'));
         return;
@@ -231,7 +227,7 @@ CacheDriver.prototype._loadSingleEntryFromCache = function(query, callback) {
     if (returnVal) {
       self._log.verbose('Returning token from cache lookup, ' + createTokenIdMessage(returnVal));
     }
-    callback(null, returnVal, isResourceSpecific);
+    callback(null, returnVal, isResourceTenantSpecific);
   });
 };
 
@@ -348,7 +344,7 @@ CacheDriver.prototype.find = function(query, callback) {
   var self = this;
   query = query || {};
   this._log.verbose('finding with query:' + JSON.stringify(query));
-  this._loadSingleEntryFromCache(query, function(err, entry, isResourceSpecific) {
+  this._loadSingleEntryFromCache(query, function(err, entry, isResourceTenantSpecific) {
     if (err) {
       callback(err);
       return;
@@ -359,7 +355,7 @@ CacheDriver.prototype.find = function(query, callback) {
       return;
     }
 
-    self._refreshEntryIfNecessary(entry, isResourceSpecific, function(err, newEntry) {
+    self._refreshEntryIfNecessary(entry, isResourceTenantSpecific, function(err, newEntry) {
       callback(err, newEntry);
       return;
     });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -103,14 +103,14 @@ var Constants = {
     },
 
     UserCodeResponseFields : {
-        USER_CODE : 'user_code', 
-        DEVICE_CODE: 'device_code', 
-        VERIFICATION_URL: 'verification_url',
-        EXPIRES_IN: 'expires_in', 
+        USER_CODE : 'userCode', 
+        DEVICE_CODE: 'deviceCode', 
+        VERIFICATION_URL: 'verificationUrl',
+        EXPIRES_IN: 'expiresIn', 
         INTERVAL: 'interval', 
         MESSAGE: 'message', 
         ERROR: 'error', 
-        ERROR_DESCRIPTION: 'error_description'
+        ERROR_DESCRIPTION: 'errorDescription'
     },
 
     IdTokenFields : {

--- a/lib/oauth2client.js
+++ b/lib/oauth2client.js
@@ -87,19 +87,31 @@ OAuth2Client.prototype._createTokenUrl = function () {
   var tokenUrl = url.parse(this._tokenEndpoint);
 
   var parameters = {};
-  parameters.slice = 'testslice';
   parameters[OAuth2Parameters.AAD_API_VERSION] = '1.0';
 
-  tokenUrl.search = querystring.stringify(parameters);
+  var queryParameter = querystring.stringify(parameters);
+  var extraQueryParam = this._callContext.extraQP;
+  if (extraQueryParam !== undefined && extraQueryParam!== null && extraQueryParam.length !== 0) {
+     if (extraQueryParam.indexOf('&') !== 0){
+       extraQueryParam = '&' + extraQueryParam;
+     }
 
+     queryParameter += extraQueryParam;
+  }
+
+  tokenUrl.search = queryParameter;
   return tokenUrl;
 };
 
+/**
+ * Constructs the user code info request url. 
+ * @private 
+ * @return {URL}
+ */
 OAuth2Client.prototype._createDeviceCodeUrl = function () {
    var deviceCodeUrl = url.parse(this._deviceCodeEndpoint);
 
    var parameters = {};
-   parameters.slice = 'testslice';
    parameters[OAuth2Parameters.AAD_API_VERSION] = '1.0';
 
    deviceCodeUrl.search = querystring.stringify(parameters);
@@ -433,7 +445,7 @@ OAuth2Client.prototype._createPostOption = function (postUrl, urlEncodedRequestF
     var postOptions = util.createRequestOptions(
         this,
     {
-            'url' : postUrl,
+            'url' : url.format(postUrl),
             body : urlEncodedRequestForm,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'

--- a/lib/oauth2client.js
+++ b/lib/oauth2client.js
@@ -89,17 +89,7 @@ OAuth2Client.prototype._createTokenUrl = function () {
   var parameters = {};
   parameters[OAuth2Parameters.AAD_API_VERSION] = '1.0';
 
-  var queryParameter = querystring.stringify(parameters);
-  var extraQueryParam = this._callContext.extraQP;
-  if (extraQueryParam !== undefined && extraQueryParam!== null && extraQueryParam.length !== 0) {
-     if (extraQueryParam.indexOf('&') !== 0){
-       extraQueryParam = '&' + extraQueryParam;
-     }
-
-     queryParameter += extraQueryParam;
-  }
-
-  tokenUrl.search = queryParameter;
+  tokenUrl.search = querystring.stringify(parameters);
   return tokenUrl;
 };
 

--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -36,7 +36,7 @@ var OAuth2Scope = constants.OAuth2.Scope;
 var Saml = constants.Saml;
 var AccountType = constants.UserRealm.AccountType;
 var WSTrustVersion = constants.WSTrustVersion;
-var DeviceCodeResponseParameters = constants.OAuth2.DeviceCodeResponseParameters;
+var DeviceCodeResponseParameters = constants.UserCodeResponseFields;
 
 /**
  * Constructs a new TokenRequest object.
@@ -160,6 +160,22 @@ TokenRequest.prototype._getTokenWithCacheWrapper = function(callback, getTokenFu
       self._log.info('Returning cached token.');
       callback(err, token);
     }
+  });
+};
+
+TokenRequest.prototype._storeTokenWithCacheWrapper = function(callback, getTokenFunc) {
+  var self = this;
+  this._cacheDriver = this._createCacheDriver();
+  getTokenFunc.call(self, function(err, tokenResponse) {
+     if (err) {
+       self._log.verbose('getTokenFunc returend with err');
+       callback(err, tokenResponse);
+       return;
+     }
+     self._log.verbose('Storing retrieved token into cache');
+     self._cacheDriver.add(tokenResponse, function() {
+       callback(null, tokenResponse);
+     });
   });
 };
 
@@ -554,9 +570,10 @@ TokenRequest.prototype.getTokenWithCertificate = function(certificate, thumbprin
 
 TokenRequest.prototype.getTokenWithDeviceCode = function(userCodeInfo, callback) {
    this._log.info('Getting a token via device code');
+   var self = this;
 
    var oauthParameters = this._createOAuthParameters(OAuth2GrantType.DEVICE_CODE);
-   oauthParameters[OAuth2Parameters.CODE] = userCodeInfo[OAuth2Parameters.DEVICE_CODE];
+   oauthParameters[OAuth2Parameters.CODE] = userCodeInfo[DeviceCodeResponseParameters.DEVICE_CODE];
 
    var interval = userCodeInfo[DeviceCodeResponseParameters.INTERVAL];
    var expires_in = userCodeInfo[DeviceCodeResponseParameters.EXPIRES_IN];
@@ -565,7 +582,7 @@ TokenRequest.prototype.getTokenWithDeviceCode = function(userCodeInfo, callback)
      callback(new Error('invalid refresh interval'));
    }
 
-   this._getTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
+   this._storeTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
         this._oauthGetTokenByPolling(oauthParameters, interval, expires_in, getTokenCompleteCallback);
    });
 };

--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -163,20 +163,16 @@ TokenRequest.prototype._getTokenWithCacheWrapper = function(callback, getTokenFu
   });
 };
 
-TokenRequest.prototype._storeTokenWithCacheWrapper = function(callback, getTokenFunc) {
-  var self = this;
-  this._cacheDriver = this._createCacheDriver();
-  getTokenFunc.call(self, function(err, tokenResponse) {
-     if (err) {
-       self._log.verbose('getTokenFunc returend with err');
-       callback(err, tokenResponse);
-       return;
-     }
-     self._log.verbose('Storing retrieved token into cache');
-     self._cacheDriver.add(tokenResponse, function() {
-       callback(null, tokenResponse);
-     });
-  });
+/**
+ * Store token into cache. 
+ * @param {object} tokenResponse Token response to be added into the cache. 
+ */
+TokenRequest.prototype._addTokenIntoCache = function(tokenResponse, callback) {
+    this._cacheDriver = this._createCacheDriver();
+    this._log.verbose('Storing retrieved token into cache');
+    this._cacheDriver.add(tokenResponse, function(err) {
+      callback(err, tokenResponse);
+    });
 };
 
 /**
@@ -582,8 +578,14 @@ TokenRequest.prototype.getTokenWithDeviceCode = function(userCodeInfo, callback)
      callback(new Error('invalid refresh interval'));
    }
 
-   this._storeTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
-        this._oauthGetTokenByPolling(oauthParameters, interval, expires_in, getTokenCompleteCallback);
+   this._oauthGetTokenByPolling(oauthParameters, interval, expires_in, function(err, tokenResponse) {
+     if (err) {
+       self._log.verbose('Token polling request returend with err.');
+       callback(err, tokenResponse);
+     }
+     else {
+       self._addTokenIntoCache(tokenResponse, callback);
+     }
    });
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "date-utils": "*",
     "jws": "3.x.x",
     "node-uuid": "1.4.1",
-    "request": ">= 2.9.203",
+    "request": ">= 2.52.0",
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
     "xpath.js": "~1.0.5", 

--- a/sample/device-code-sample.js
+++ b/sample/device-code-sample.js
@@ -24,6 +24,7 @@ var fs = require('fs');
 var adal = require('../lib/adal.js');
 var async = require('async');
 var url = require('url');
+var MemoryCache = require('../lib/memory-cache');
 
 var AuthenticationContext = adal.AuthenticationContext;
 
@@ -67,20 +68,23 @@ if (parametersFile) {
 
 if (!parametersFile) {
     sampleParameters = {
-        tenant : '',
-        authorityHostUrl : '',
-        clientId : ''
+        tenant : 'convergeTest.onmicrosoft.com',
+        authorityHostUrl : 'https://login.microsoftonline.com',
+        clientId : '',
+        anothertenant: ''
     };
 }
 
 var authorityUrl = sampleParameters.authorityHostUrl + '/' + sampleParameters.tenant;
 
 var resource = '00000002-0000-0000-c000-000000000000';
+var userId = '';
 
 //turnOnLogging();
 
-var context = new AuthenticationContext(authorityUrl);
+var cache = new MemoryCache();
 
+var context = new AuthenticationContext(authorityUrl, null, cache);
 context.acquireUserCode(resource, sampleParameters.clientId, 'es-mx', function (err, response) {
     if (err) {
         console.log('well that didn\'t work: ' + err.stack);
@@ -93,8 +97,20 @@ context.acquireUserCode(resource, sampleParameters.clientId, 'es-mx', function (
                 console.log(err);
             }
             else {
-                console.log(tokenResponse);
+                authorityUrl = sampleParameters.authorityHostUrl + '/' + sampleParameters.anothertenant;
+                
+                var context2 = new AuthenticationContext(authorityUrl, null, cache);
+                context2.acquireToken(resource, userId, sampleParameters.clientId, function (err, tokenResponse) {
+                    if (err) {
+                        console.log('error happens when acquiring token with device code');
+                        console.log(err);
+                    }
+                    else {
+                        console.log(tokenResponse);
+                    }
+                });
             }
         });
     }
 });
+

--- a/test/cache-driver.js
+++ b/test/cache-driver.js
@@ -35,7 +35,7 @@ var testRequire = util.testRequire;
 var assert = require('assert');
 
 var MemoryCache = testRequire('memory-cache');
-var CacheDriver = testRequire('cache-driver');
+var CacheDriver = testRequire('../lib/cache-driver');
 
 suite('CacheDriver', function() {
 
@@ -214,6 +214,7 @@ suite('CacheDriver', function() {
           authority : authority,
           expiredEntry : expiredEntry
         };
+
         callback(err, testValues, finalRefreshToken);
       }
     );
@@ -231,7 +232,7 @@ suite('CacheDriver', function() {
 
         var otherAuthority = 'someOtherAuthority';
         var responseOptions = { authority : otherAuthority, mrrt : true, resource : responses[0].resource };
-        var differentAuthorityResponse = util.createResponse(responseOptions);
+        var differentAuthorityResponse = util.createResponse(responseOptions, 21);
         delete responseOptions.authority;
         var extraMRRTResponse = util.createResponse(responseOptions, 21);
         responses.push(extraMRRTResponse.cachedResponse);
@@ -240,6 +241,7 @@ suite('CacheDriver', function() {
 
         // order is important here.  We want to ensure that when we add the second MRRT it has only updated
         // the refresh token of the entries with the same authority.
+        // update: with mega refresh token(cross tenant RT), refresh token of the entry will be updated if there is a match with userId, clientId. 
         var cacheDriver = new CacheDriver(fakeTokenRequest._callContext, otherAuthority, differentAuthorityResponse.resource, differentAuthorityResponse.clientId, memCache, unexpectedRefreshFunction);
         cacheDriver.add(differentAuthorityResponse.decodedResponse, function(err) {
           assert(!err, 'Unexpected err adding entry with different authority.');
@@ -247,7 +249,6 @@ suite('CacheDriver', function() {
           var cacheDriver2 = new CacheDriver(fakeTokenRequest._callContext, cp.authorityTenant, extraMRRTResponse.resource, extraMRRTResponse.clientId, memCache, unexpectedRefreshFunction);
           cacheDriver2.add(extraMRRTResponse.decodedResponse, function(err2) {
             assert(!err2, 'Unexpected error adding second entry with previous authority.');
-            compareInputAndCache(responses, memCache, numMRRTTokens);
 
             // ensure that we only find the mrrt with the different authority.
             cacheDriver.find( { resource : differentAuthorityResponse.resource}, function(err3, entry) {
@@ -396,6 +397,7 @@ suite('CacheDriver', function() {
       var responseOptions = { resource : unknownResource, mrrt : true, refreshedRefresh : true };
       var refreshedResponse = util.createResponse(responseOptions);
       var refreshedRefreshToken = refreshedResponse.refreshToken;
+
       var refreshFunction = createRefreshFunction(finalMrrt, refreshedResponse.decodedResponse);
 
       if (!err) {

--- a/test/cache-driver.js
+++ b/test/cache-driver.js
@@ -35,7 +35,7 @@ var testRequire = util.testRequire;
 var assert = require('assert');
 
 var MemoryCache = testRequire('memory-cache');
-var CacheDriver = testRequire('../lib/cache-driver');
+var CacheDriver = testRequire('cache-driver');
 
 suite('CacheDriver', function() {
 

--- a/test/device-code.js
+++ b/test/device-code.js
@@ -52,37 +52,17 @@ suite('device-code', function () {
         
         var query = querystring.stringify(queryParameters);
 
-        var tokenUrlPath = cp.tokenUrlPath;
-        if (extraQP !== undefined && extraQP !== null) {
-           tokenUrlPath += extraQP;
-        }
-        
         var tokenRequest = nock(authEndpoint)
                                 .filteringRequestBody(function (body) {
                                     return util.filterQueryString(query, body);
                                  })
-                                .post(tokenUrlPath, query)
+                                .post(cp.tokenUrlPath, query)
                                 .reply(httpCode, returnDoc);
         
         util.matchStandardRequestHeaders(tokenRequest);
         
         return tokenRequest;
     }
-
-    test('happy-path-with-extraqp', function (done) {
-        var response = util.createResponse();
-        var tokenRequest = setupExpectedTokenRequestResponse(200, response.wireResponse, null, '&a=b&b=c');
-
-        var userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 1 };
-        var context = new AuthenticationContext(cp.authUrl);
-        context.extraQP = 'a=b&b=c';
-        context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err, tokenResponse) {
-            assert(!err, 'Receive unexpected error');
-            tokenRequest.done();
-            done(err);
-        });
-        
-    });
 
     test('happy-path-successOnFirstRequest', function (done) {
         var response = util.createResponse();

--- a/test/device-code.js
+++ b/test/device-code.js
@@ -41,7 +41,7 @@ suite('device-code', function () {
         util.clearStaticCache();
     });
 
-    function setupExpectedTokenRequestResponse(httpCode, returnDoc, authorityEndpoint) {
+    function setupExpectedTokenRequestResponse(httpCode, returnDoc, authorityEndpoint, extraQP) {
         var authEndpoint = util.getNockAuthorityHost(authorityEndpoint);
         
         var queryParameters = {};
@@ -51,24 +51,44 @@ suite('device-code', function () {
         queryParameters['code'] = cp.deviceCode;
         
         var query = querystring.stringify(queryParameters);
+
+        var tokenUrlPath = cp.tokenUrlPath;
+        if (extraQP !== undefined && extraQP !== null) {
+           tokenUrlPath += extraQP;
+        }
         
         var tokenRequest = nock(authEndpoint)
                                 .filteringRequestBody(function (body) {
                                     return util.filterQueryString(query, body);
                                  })
-                                .post(cp.tokenUrlPath, query)
+                                .post(tokenUrlPath, query)
                                 .reply(httpCode, returnDoc);
         
         util.matchStandardRequestHeaders(tokenRequest);
         
         return tokenRequest;
     }
-    
+
+    test('happy-path-with-extraqp', function (done) {
+        var response = util.createResponse();
+        var tokenRequest = setupExpectedTokenRequestResponse(200, response.wireResponse, null, '&a=b&b=c');
+
+        var userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 1 };
+        var context = new AuthenticationContext(cp.authUrl);
+        context.extraQP = 'a=b&b=c';
+        context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err, tokenResponse) {
+            assert(!err, 'Receive unexpected error');
+            tokenRequest.done();
+            done(err);
+        });
+        
+    });
+
     test('happy-path-successOnFirstRequest', function (done) {
         var response = util.createResponse();
         var tokenRequest = setupExpectedTokenRequestResponse(200, response.wireResponse);
         
-        var userCodeInfo = { device_code: cp.deviceCode, interval: 1, expires_in: 1 };
+        var userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 1 };
         var context = new AuthenticationContext(cp.authUrl);
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err, tokenResponse) {
             assert(!err, 'Receive unexpected error');
@@ -107,7 +127,7 @@ suite('device-code', function () {
         var response = util.createResponse();
         var tokenRequest = setupExpectedTokenRequestResponseWithAuthPending(response.wireResponse);
         
-        var userCodeInfo = { device_code: cp.deviceCode, interval: 1, expires_in: 200 };
+        var userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 200 };
         var context = new AuthenticationContext(cp.authUrl);
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err, tokenResponse) {
            if (!err) {
@@ -123,7 +143,7 @@ suite('device-code', function () {
         var response = util.createResponse();
         var tokenRequest = setupExpectedTokenRequestResponseWithAuthPending(response.wireResponse);
         
-        var userCodeInfo = { device_code: cp.deviceCode, interval: 1, expires_in: 200 };
+        var userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 200 };
         var context = new AuthenticationContext(cp.authUrl);
 
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err, tokenResponse) {
@@ -141,19 +161,19 @@ suite('device-code', function () {
         nock.cleanAll();
         var context = new AuthenticationContext(cp.authUrl);
 
-        var userCodeInfo = { interval: 5, expires_in: 1000};
+        var userCodeInfo = { interval: 5, expiresIn: 1000};
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err) {
             assert(err, 'Did not receive expected argument error');
             assert(err.message === 'The userCodeInfo is missing device_code');
         });
 
-        userCodeInfo = { device_code: 'test_device_code', expires_in: 1000 };
+        userCodeInfo = { deviceCode: 'test_device_code', expiresIn: 1000 };
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err) {
             assert(err, 'Did not receive expected argument error');
             assert(err.message === 'The userCodeInfo is missing interval');
         });
 
-        userCodeInfo = { device_code: 'test_device_code', interval: 5 };
+        userCodeInfo = { deviceCode: 'test_device_code', interval: 5 };
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err) {
             assert(err, 'Did not receive expected argument error');
             assert(err.message === 'The userCodeInfo is missing expires_in');
@@ -165,7 +185,7 @@ suite('device-code', function () {
             assert(err.message === 'The userCodeInfo parameter is required');
         });
 
-        userCodeInfo = { device_code: 'test_device_code', interval: 5, expires_in: 1000 };
+        userCodeInfo = { deviceCode: 'test_device_code', interval: 5, expiresIn: 1000 };
         try {
             context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo);
         } catch (e) {
@@ -173,7 +193,7 @@ suite('device-code', function () {
             assert(e.message === 'acquireToken requires a function callback parameter.', 'Unexpected error message returned.');
         }
 
-        userCodeInfo = { device_code: 'test_device_code', interval: 0, expires_in: 1000 };
+        userCodeInfo = { deviceCode: 'test_device_code', interval: 0, expiresIn: 1000 };
         context.acquireTokenWithDeviceCode(cp.resource, cp.clientId, userCodeInfo, function (err) {
           assert(err, 'Did not receive expected error.');
           assert(err.message === 'invalid refresh interval');
@@ -185,7 +205,7 @@ suite('device-code', function () {
     test('bad-argument-cancel-request', function (done) {
        var context = new AuthenticationContext(cp.authUrl);
 
-        var userCodeInfo = { interval: 5, expires_in: 1000 };
+        var userCodeInfo = { interval: 5, expiresIn: 1000 };
         context.cancelRequestToGetTokenWithDeviceCode(userCodeInfo, function (err) {
             assert(err, 'Did not receive expected argument error');
             assert(err.message === 'The userCodeInfo is missing device_code');
@@ -197,7 +217,7 @@ suite('device-code', function () {
             assert(err.message === 'The userCodeInfo parameter is required');
         });
 
-        userCodeInfo = { device_code: 'test_device_code', interval: 5, expires_in: 1000 };
+        userCodeInfo = { deviceCode: 'test_device_code', interval: 5, expiresIn: 1000 };
         try {
             context.cancelRequestToGetTokenWithDeviceCode(userCodeInfo);
         } catch (e) {
@@ -205,7 +225,7 @@ suite('device-code', function () {
             assert(e.message === 'acquireToken requires a function callback parameter.', 'Unexpected error message returned.');
         }
 
-        userCodeInfo = { device_code: cp.deviceCode, interval: 1, expires_in: 200 };
+        userCodeInfo = { deviceCode: cp.deviceCode, interval: 1, expiresIn: 200 };
         context.cancelRequestToGetTokenWithDeviceCode(userCodeInfo, function (err) {
             assert(err, 'Did not receive expected error. ');
             assert(err.message === 'No acquireTokenWithDeviceCodeRequest existed to be cancelled', 'Unexpected error message returned.');

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -217,6 +217,12 @@ function mapFields(inObj, outObj, map) {
   }
 }
 
+/**
+ * Create response based on the given options and iteration number. 
+ * @options Options is used to flex the reponse creation, i.e authority, resource and isMRRT. 
+ * @param iteration Iteraton will be used to create a distinct token for each value of iteration and it will always return that same token 
+ *                  for same value of iteration. 
+ */
 util.createResponse = function(options, iteration) {
   options = options || {};
 

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -120,9 +120,10 @@ parameters.successResponse = successResponse;
 parameters.successResponseWithRefresh = successResponseWithRefresh;
 parameters.authUrl = url.parse(parameters.evoEndpoint + '/' + parameters.tenant);
 parameters.tokenPath = '/oauth2/token';
-parameters.tokenUrlPath = parameters.authUrl.pathname + parameters.tokenPath;
+parameters.extraQP = '?api-version=1.0';
+parameters.tokenUrlPath = parameters.authUrl.pathname + parameters.tokenPath + parameters.extraQP;
 parameters.deviceCodePath = '/oauth2/devicecode'
-parameters.deviceCodeUrlPath = parameters.authUrl.pathname + parameters.deviceCodePath;
+parameters.deviceCodeUrlPath = parameters.authUrl.pathname + parameters.deviceCodePath + parameters.extraQP;
 parameters.authorizePath = '/oauth/authorize';
 parameters.authorizeUrlPath = parameters.authUrl.pathname + parameters.authorizePath;
 parameters.authorizeUrl = parameters.authUrl.href + parameters.authorizePath;
@@ -199,13 +200,13 @@ TOKEN_RESPONSE_MAP['error_description'] = 'errorDescription';
 TOKEN_RESPONSE_MAP['resource'] = 'resource';
 
 var DEVICE_CODE_RESPONSE_MAP = {};
-DEVICE_CODE_RESPONSE_MAP['device_code'] = 'device_code';
-DEVICE_CODE_RESPONSE_MAP['user_code'] = 'user_code';
-DEVICE_CODE_RESPONSE_MAP['verification_url'] = 'verification_url';
+DEVICE_CODE_RESPONSE_MAP['device_code'] = 'deviceCode';
+DEVICE_CODE_RESPONSE_MAP['user_code'] = 'userCode';
+DEVICE_CODE_RESPONSE_MAP['verification_url'] = 'verificationUrl';
 DEVICE_CODE_RESPONSE_MAP['interval'] = 'interval';
-DEVICE_CODE_RESPONSE_MAP['expires_in'] = 'expires_in';
+DEVICE_CODE_RESPONSE_MAP['expires_in'] = 'expiresIn';
 DEVICE_CODE_RESPONSE_MAP['error'] = 'error';
-DEVICE_CODE_RESPONSE_MAP['error_description'] = 'error_description';
+DEVICE_CODE_RESPONSE_MAP['error_description'] = 'errorDescription';
 
 function mapFields(inObj, outObj, map) {
   for (var key in inObj) {
@@ -277,6 +278,7 @@ util.createResponse = function(options, iteration) {
   decodedResponse['expiresOn'] = expiresOnDate;
 
   var cachedResponse = _.clone(decodedResponse);
+
   cachedResponse['_clientId'] = parameters.clientId;
   cachedResponse['_authority'] = authority;
   cachedResponse['resource'] = iterated['resource'];


### PR DESCRIPTION
Changes:
1. modify cache logic to support cross tenant refresh token
2. modify the cache logic for current device code flow, acquireTokenWithDeviceCode won't do cache lookup, it will only store returned token into cache, for cache lookup developer needs to call acquireToken. 
3. add another property 'extraQP' in authenticationcontext. This could be used to set the extra query parameter passed to tokenendpoint.  