### PR TITLE
[Do not merge]Surface correct error rather a general 'Entry not found in cache.'

### DIFF
--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -155,7 +155,7 @@ TokenRequest.prototype._getTokenWithCacheWrapper = function(callback, getTokenFu
         self._cacheDriver.add(tokenResponse, function() {
           callback(null, tokenResponse);
         });
-      });
+      }, err);
     } else {
       self._log.info('Returning cached token.');
       callback(err, token);
@@ -508,11 +508,11 @@ TokenRequest.prototype.getTokenFromCacheWithRefresh = function(userId, callback)
   this._log.info('Getting token from cache with refresh if necessary.');
 
   this._userId = userId;
-  this._getTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
+  this._getTokenWithCacheWrapper(callback, function(getTokenCompleteCallback, err) {
     // If this method was called then no cached entry was found.  Since
     // this particular version of acquireToken can only retrieve tokens
     // from the cache, return an error.
-    getTokenCompleteCallback(self._log.createError('Entry not found in cache.'));
+    getTokenCompleteCallback(self._log.createError(err || 'Entry not found in cache.'));
   });
 };
 


### PR DESCRIPTION
The error of "Entry not found in cache" is rather general,and hard to diagnose for a client app. We should surface the right error, rather asking external clients to turn on verbose log and capture the log. Worse, for azure-cli, some clients end up sending in logs containing their credentials.

@RandalliLama @weijjia , if the idea is approved, i can follow up with the necessary refactoring per suggestion, and related tests.
