### PR TITLE
fixed code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ var AuthenticationContext = require('adal-node').AuthenticationContext;
 
 var clientId = 'yourClientIdHere';
 var clientSecret = 'yourAADIssuedClientSecretHere'
-var redirectUri = 'yourRedirectUriHere';
 var authorityHostUrl = 'https://login.windows.net';
 var tenant = 'myTenant';
 var authorityUrl = authorityHostUrl + '/' + tenant;
@@ -40,8 +39,8 @@ var templateAuthzUrl = 'https://login.windows.net/' +
                         '/oauth2/authorize?response_type=code&client_id=' +
                         clientId + 
                         '&redirect_uri=' + 
-                        redirectUri + '
-                        &state=<state>&resource=' + 
+                        redirectUri + 
+                        '&state=<state>&resource=' + 
                         resource;
 
 function createAuthorizationUrl(state) {


### PR DESCRIPTION
At Authorization Code sample redirectUri is 2 times defined and templateAuthzUrl string is invalid, single quotation mark is at the end of line instead at the start of next line.