### PR TITLE
should be possible to inline the adal version during compile time

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -34,8 +34,8 @@ var ADAL_VERSION;
  */
 
 function loadAdalVersion() {
-  var packagePath = __dirname + '/../package.json';
-  var packageJson = JSON.parse(fs.readFileSync(packagePath));
+  var packageData = fs.readFileSync(__dirname + '/../package.json');
+  var packageJson = JSON.parse(packageData);
   ADAL_VERSION = packageJson.version;
 }
 


### PR DESCRIPTION
* e.g. browserify brfs can inline static assets if the identifier is resolvable and of static nature
  readFileSync (__dirname + '.....')