### PR TITLE
Using dependency marked as insecure: node-uuid@1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "date-utils": "*",
     "jws": "3.x.x",
-    "node-uuid": "1.4.1",
+    "node-uuid": "1.4.7",
     "request": ">= 2.52.0",
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",


### PR DESCRIPTION
The previously used version of node-uuid has a security issue.

> node-uuid prior to 1.4.4 contained a bug that caused it to consistently
> fall back to using Math.random instead of a more cryptographically sound source of entropy, the native crypto module.

As reported in the [Node Security Project](https://nodesecurity.io/advisories/93).
This fixes #106