### PR TITLE
Update for US Government and German Government Authority Instances

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -140,7 +140,7 @@ var Constants = {
 
     AADConstants : {
       WORLD_WIDE_AUTHORITY : 'login.windows.net',
-      WELL_KNOWN_AUTHORITY_HOSTS : ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login.cloudgovapi.us'],
+      WELL_KNOWN_AUTHORITY_HOSTS : ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login-us.microsoftonline.com', 'login.microsoftonline.de'],
       INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE : 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0',
       AUTHORIZE_ENDPOINT_PATH : '/oauth2/authorize',
       TOKEN_ENDPOINT_PATH : '/oauth2/token', 

--- a/test/authority.js
+++ b/test/authority.js
@@ -129,7 +129,7 @@ suite('Authority', function() {
             done(err3);
             return;
           }
-          performStaticInstanceDiscovery('login.cloudgovapi.us', function(err4) {
+          performStaticInstanceDiscovery('login-us.microsoftonline.com', function(err4) {
               done(err4);
           });
         });

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -98,7 +98,7 @@ parameters.password = 'Atestpass!@#$';
 parameters.authorityHosts = {
   global : 'login.windows.net',
   china : 'login.chinacloudapi.cn',
-  gov : 'login.cloudgovapi.us'
+  gov : 'login-us.microsoftonline.com'
 };
 parameters.language = 'en';
 parameters.deviceCode = 'ABCDE:device_code';


### PR DESCRIPTION
This change adds 2 federation providers to the whitelist of federation providers in the ADAL library
    1. The US government one (login-us.microsoftonline.com)
    2. The German government one (login.microsoftonline.de)