### PR TITLE
add support for resource owner grant flow for ADFS

### DIFF
--- a/lib/authority.js
+++ b/lib/authority.js
@@ -42,7 +42,6 @@ function Authority(authorityUrl, validateAuthority) {
   this._validateAuthorityUrl();
 
   this._validated = !validateAuthority;
-
   this._host = null;
   this._tenant = null;
   this._parseAuthority();
@@ -50,6 +49,7 @@ function Authority(authorityUrl, validateAuthority) {
   this._authorizationEndpoint = null;
   this._tokenEndpoint = null;
   this._deviceCodeEndpoint = null;
+  this._isAdfsAuthority = (this._tenant.toLowerCase() === "adfs");
 }
 
 /**
@@ -233,7 +233,7 @@ Authority.prototype._getOAuthEndpoints = function(tenantDiscoveryEndpoint, callb
     if (!this._deviceCodeEndpoint){
        this._deviceCodeEndpoint = url.format(this._url) + AADConstants.DEVICE_ENDPOINT_PATH;
     }
-    
+
     callback();
     return;
   }

--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -164,8 +164,8 @@ TokenRequest.prototype._getTokenWithCacheWrapper = function(callback, getTokenFu
 };
 
 /**
- * Store token into cache. 
- * @param {object} tokenResponse Token response to be added into the cache. 
+ * Store token into cache.
+ * @param {object} tokenResponse Token response to be added into the cache.
  */
 TokenRequest.prototype._addTokenIntoCache = function(tokenResponse, callback) {
     this._cacheDriver = this._createCacheDriver();
@@ -275,7 +275,7 @@ TokenRequest.prototype._performWSTrustAssertionOAuthExchange = function(wstrustR
 /**
  * Exchange a username and password for a SAML token from an ADFS instance via WSTrust.
  * @param  {string}   wstrustEndpoint An url of an ADFS WSTrust endpoint.
- * @param  {string}   wstrustEndpointVersion The version of the wstrust endpoint. 
+ * @param  {string}   wstrustEndpointVersion The version of the wstrust endpoint.
  * @param  {string}   username        username
  * @param  {string}   password        password
  * @param  {AcquireTokenCallback} callback        callback
@@ -379,19 +379,19 @@ TokenRequest.prototype._getTokenUsernamePasswordFederated = function(username, p
  * Gets wstrust endpoint version from the federation active auth url.
  * @private
  * @param  {string}   federationActiveAuthUrl  federationActiveAuthUrl
- * @return {object}   The wstrust endpoint version.  
+ * @return {object}   The wstrust endpoint version.
  */
 TokenRequest.prototype._parseWStrustVersionFromFederationActiveAuthUrl = function(federationActiveAuthUrl) {
     var wstrust2005Regex = /[/trust]?[2005][/usernamemixed]?/;
     var wstrust13Regex = /[/trust]?[13][/usernamemixed]?/;
-    
+
     if (wstrust2005Regex.exec(federationActiveAuthUrl)) {
         return WSTrustVersion.WSTRUST2005;
     }
     else if (wstrust13Regex.exec(federationActiveAuthUrl)) {
         return WSTrustVersion.WSTRUST13;
     }
-    
+
     return WSTrustVersion.UNDEFINED;
 };
 
@@ -405,10 +405,18 @@ TokenRequest.prototype._parseWStrustVersionFromFederationActiveAuthUrl = functio
  */
 TokenRequest.prototype.getTokenWithUsernamePassword = function(username, password, callback) {
   this._log.info('Acquiring token with username password');
-
   this._userId = username;
+
   this._getTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
     var self = this;
+
+      if(this._authenticationContext._authority._isAdfsAuthority) {
+        this._log.info('Skipping user realm discovery for ADFS authority');
+
+        self._getTokenUsernamePasswordManaged(username, password, getTokenCompleteCallback);
+        return;
+      }
+
     this._userRealm = this._createUserRealmRequest(username);
     this._userRealm.discover(function(err) {
       if (err) {


### PR DESCRIPTION
This change allows for the developer to execute resource owner grant flow against ADFS as an authority. user realm discovery is skipped because it is AAD specific.