### PR TITLE
Fixed RSTR returned unknown token type error from WS-Trust endpoint version 1.3 

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,9 +36,9 @@ var Constants = {
         AAD_API_VERSION : 'api-version',
         USERNAME : 'username',
         PASSWORD : 'password',
-        REFRESH_TOKEN : 'refresh_token', 
-        LANGUAGE : 'mkt', 
-        DEVICE_CODE : 'device_code', 
+        REFRESH_TOKEN : 'refresh_token',
+        LANGUAGE : 'mkt',
+        DEVICE_CODE : 'device_code',
       },
 
       GrantType : {
@@ -67,13 +67,13 @@ var Constants = {
       },
 
       DeviceCodeResponseParameters : {
-         USER_CODE : 'user_code', 
-         DEVICE_CODE : 'device_code', 
+         USER_CODE : 'user_code',
+         DEVICE_CODE : 'device_code',
          VERIFICATION_URL : 'verification_url',
-         EXPIRES_IN : 'expires_in', 
-         INTERVAL: 'interval', 
-         MESSAGE: 'message', 
-         ERROR: 'error', 
+         EXPIRES_IN : 'expires_in',
+         INTERVAL: 'interval',
+         MESSAGE: 'message',
+         ERROR: 'error',
          ERROR_DESCRIPTION: 'error_description'
       },
 
@@ -104,13 +104,13 @@ var Constants = {
     },
 
     UserCodeResponseFields : {
-        USER_CODE : 'userCode', 
-        DEVICE_CODE: 'deviceCode', 
+        USER_CODE : 'userCode',
+        DEVICE_CODE: 'deviceCode',
         VERIFICATION_URL: 'verificationUrl',
-        EXPIRES_IN: 'expiresIn', 
-        INTERVAL: 'interval', 
-        MESSAGE: 'message', 
-        ERROR: 'error', 
+        EXPIRES_IN: 'expiresIn',
+        INTERVAL: 'interval',
+        MESSAGE: 'message',
+        ERROR: 'error',
         ERROR_DESCRIPTION: 'errorDescription'
     },
 
@@ -143,7 +143,7 @@ var Constants = {
       WELL_KNOWN_AUTHORITY_HOSTS : ['login.windows.net', 'login.microsoftonline.com', 'login.chinacloudapi.cn', 'login-us.microsoftonline.com', 'login.microsoftonline.de'],
       INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE : 'https://{authorize_host}/common/discovery/instance?authorization_endpoint={authorize_endpoint}&api-version=1.0',
       AUTHORIZE_ENDPOINT_PATH : '/oauth2/authorize',
-      TOKEN_ENDPOINT_PATH : '/oauth2/token', 
+      TOKEN_ENDPOINT_PATH : '/oauth2/token',
       DEVICE_ENDPOINT_PATH : '/oauth2/devicecode'
     },
 
@@ -162,8 +162,8 @@ var Constants = {
     },
 
     Saml : {
-      TokenTypeV1 : 'urn:oasis:names:tc:SAML:1.0:assertion',
-      TokenTypeV2 : 'urn:oasis:names:tc:SAML:2.0:assertion'
+      TokenTypeV1 : ['urn:oasis:names:tc:SAML:1.0:assertion', 'http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1'],
+      TokenTypeV2 : ['urn:oasis:names:tc:SAML:2.0:assertion', 'http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0']
     },
 
     XmlNamespaces : {
@@ -177,7 +177,7 @@ var Constants = {
       wsp    : 'http://schemas.xmlsoap.org/ws/2004/09/policy',
       s      : 'http://www.w3.org/2003/05/soap-envelope',
       wsa    : 'http://www.w3.org/2005/08/addressing',
-      wst    : 'http://docs.oasis-open.org/ws-sx/ws-trust/200512', 
+      wst    : 'http://docs.oasis-open.org/ws-sx/ws-trust/200512',
       t      : 'http://schemas.xmlsoap.org/ws/2005/02/trust'
     },
 
@@ -198,10 +198,10 @@ var Constants = {
     },
 
     WSTrustVersion : {
-       UNDEFINED : 'undefined', 
-       WSTRUST13 : 'wstrust13', 
+       UNDEFINED : 'undefined',
+       WSTRUST13 : 'wstrust13',
        WSTRUST2005 : 'wstrust2005'
-    } 
+    }
   };
 
 module.exports = Constants;

--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -239,13 +239,12 @@ TokenRequest.prototype._getTokenUsernamePasswordManaged = function(username, pas
  */
 TokenRequest.prototype._getSamlGrantType = function(wstrustResponse) {
   var tokenType = wstrustResponse.tokenType;
-  switch (tokenType) {
-    case Saml.TokenTypeV1:
-      return OAuth2GrantType.SAML1;
-    case Saml.TokenTypeV2:
-      return OAuth2GrantType.SAML2;
-    default:
-      throw this._log.createError('RSTR returned unknown token type: ' + tokenType);
+  if (Saml.TokenTypeV1.indexOf(tokenType) !== -1) {
+    return OAuth2GrantType.SAML1;
+  } else if (Saml.TokenTypeV2.indexOf(tokenType) !== -1) {
+    return OAuth2GrantType.SAML2;
+  } else {
+    throw this._log.createError('RSTR returned unknown token type: ' + tokenType);
   }
 };
 

--- a/lib/wstrust-response.js
+++ b/lib/wstrust-response.js
@@ -65,7 +65,7 @@ function scrubRSTRLogMessage(RSTR) {
  * @private
  * @param {object} callContext Contains any context information that applies to the request.
  * @param {string} response   A soap response from a WS-Trust request.
- * @param {sting}  wstrustVersion The version for the WS-Trust request. 
+ * @param {sting}  wstrustVersion The version for the WS-Trust request.
  */
 function WSTrustResponse(callContext, response, wstrustVersion) {
   this._log = new Logger('WSTrustResponse', callContext._logContext);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
     "xpath.js": "~1.0.5", 
-    "async": ">=0.6.0"
+    "async": "2.0.0"
   },
   "devDependencies": {
     "jshint": "*",

--- a/test/wstrust-response.js
+++ b/test/wstrust-response.js
@@ -143,13 +143,25 @@ suite('WSTrustResponse', function() {
 
   test('happy-path-wstrust2005', function(done) {
     var tokenResponse = fs.readFileSync(__dirname + '/wstrust/RSTR2005.xml', 'utf8');
-        
+
     var wstrustResponse = new WSTrustResponse(cp.callContext, tokenResponse, WSTrustVersion.WSTRUST2005);
-        
+
     wstrustResponse.parse();
     assert(wstrustResponse.tokenType === 'urn:oasis:names:tc:SAML:1.0:assertion', 'TokenType did not match expected value: ' + wstrustResponse.tokenType);
     assert(-1 !== wstrustResponse.token.indexOf('y7TujD6J60uo1eFddnNJ1g=='), 'Did not find expected ImmutableID value in Token property: ' + wstrustResponse.token);
     done();
   });
+
+  test('token-parsing-happy-wstrust13', function(done) {
+    var tokenResponse = fs.readFileSync(__dirname + '/wstrust/RSTR13.xml', 'utf8');
+
+    var wstrustResponse = new WSTrustResponse(cp.callContext, tokenResponse, WSTrustVersion.WSTRUST13);
+
+    wstrustResponse.parse();
+    assert(wstrustResponse.tokenType === 'http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1', 'TokenType did not match expected value: ' + wstrustResponse.tokenType);
+    assert(-1 !== wstrustResponse.token.indexOf('drxWGX7IeU6m2/uJpMztsQ=='), 'Did not find expected ImmutableID value in Token property: ' + wstrustResponse.token);
+    done();
+  });
+ 
 });
 

--- a/test/wstrust/RSTR13.xml
+++ b/test/wstrust/RSTR13.xml
@@ -1,0 +1,90 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+	<s:Header>
+		<add:To xmlns:add="http://www.w3.org/2005/08/addressing">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</add:To>
+		<add:Action xmlns:add="http://www.w3.org/2005/08/addressing">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal</add:Action>
+		<wsse:Security s:mustUnderstand="1" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+			<wsu:Timestamp wsu:Id="8c07759c-91bf-4eec-8639-6614ada2bf9e" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+				<wsu:Created>2016-07-02T03:10:00.440Z</wsu:Created>
+				<wsu:Expires>2016-07-02T03:15:00.440Z</wsu:Expires>
+			</wsu:Timestamp>
+		</wsse:Security>
+	</s:Header>
+	<s:Body>
+		<wst13:RequestSecurityTokenResponseCollection xmlns:wst13="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+			<wst13:RequestSecurityTokenResponse>
+				<wst13:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1</wst13:TokenType>
+				<wst13:RequestedSecurityToken>
+					<saml:Assertion AssertionID="OaAodEmXNi7e-tYhxTRKUH4RaPl" IssueInstant="2016-07-02T03:10:00.440Z" Issuer="TEST_SAML" MajorVersion="1" MinorVersion="1" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion">
+						<saml:Conditions NotBefore="2016-07-02T02:05:00.440Z" NotOnOrAfter="2016-07-02T04:15:00.440Z">
+							<saml:AudienceRestrictionCondition>
+								<saml:Audience>urn:federation:MicrosoftOnline</saml:Audience>
+							</saml:AudienceRestrictionCondition>
+						</saml:Conditions>
+						<saml:AuthenticationStatement AuthenticationInstant="2016-07-02T03:10:00.440Z" AuthenticationMethod="urn:oasis:names:tc:SAML:1.0:am:unspecified">
+							<saml:Subject>
+								<saml:NameIdentifier Format="http://schemas.xmlsoap.org/claims/UPN">USERID</saml:NameIdentifier>
+								<saml:SubjectConfirmation>
+									<saml:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:bearer</saml:ConfirmationMethod>
+								</saml:SubjectConfirmation>
+							</saml:Subject>
+						</saml:AuthenticationStatement>
+						<saml:AttributeStatement>
+							<saml:Subject>
+								<saml:NameIdentifier Format="http://schemas.xmlsoap.org/claims/UPN">USERID</saml:NameIdentifier>
+								<saml:SubjectConfirmation>
+									<saml:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:bearer</saml:ConfirmationMethod>
+								</saml:SubjectConfirmation>
+							</saml:Subject>
+							<saml:Attribute AttributeName="UPN" AttributeNamespace="http://schemas.xmlsoap.org/claims">
+								<saml:AttributeValue>User1UserName</saml:AttributeValue>
+							</saml:Attribute>
+							<saml:Attribute AttributeName="ImmutableID" AttributeNamespace="http://schemas.microsoft.com/LiveID/Federation/2008/05">
+								<saml:AttributeValue>drxWGX7IeU6m2/uJpMztsQ==</saml:AttributeValue>
+							</saml:Attribute>
+						</saml:AttributeStatement>
+						<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+							<ds:SignedInfo>
+								<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+								<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+								<ds:Reference URI="#OnAodEmXNi7e-tYhxTRKUH4RaPl">
+									<ds:Transforms>
+										<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+										<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+									</ds:Transforms>
+									<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+									<ds:DigestValue>slbNm0oe0b4bWOmIKsXxNXVsXTo=</ds:DigestValue>
+								</ds:Reference>
+							</ds:SignedInfo>
+							<ds:SignatureValue>
+                                qvQhD1wODnTSpMbeWzjUZLJn8+//pj2ZsrzjId2fW+pOvo8T9pUqHg8XYo8PZhltLmttiA4ECQSd
+                                IHVVGldCWSc7RlLiwa9YVJZsBjXzltkIAxzve9UQD6DzsnF09bvqgXjdrvYsD0wOP2AoB1x724Ca
+                                l6CsvVDK+8n4/lOjK07RyOYhWwnxRgxDiJ3w2tRnHFtJo6hNLGMmpj8vewBLouxJ8QQxdZT8jWKG
+                                Q8qR0zbK/UPSVFdSnmYXG8adwDkx0Bsny5m5E9hbVAF5c5D5+WJOTrOT+fXW6S5uddrortlDnpev
+                                wQaSomV4u6OfjzBY4MV3N76QwY24X/+tHprh+Q==
+                                </ds:SignatureValue>
+							<ds:KeyInfo>
+								<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+									<wsse:KeyIdentifier ValueType="http://docs.oasis-open.org/wss/oasis-wss-soap-message-security-1.1#ThumbprintSHA1">3xs9wRWGBzy0c8GUgSIPmxB3Y/g=</wsse:KeyIdentifier>
+								</wsse:SecurityTokenReference>
+							</ds:KeyInfo>
+						</ds:Signature>
+					</saml:Assertion>
+				</wst13:RequestedSecurityToken>
+				<wst13:Lifetime>
+					<wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-07-02T03:10:00.440Z</wsu:Created>
+					<wsu:Expires xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2016-07-02T04:15:00.440Z</wsu:Expires>
+				</wst13:Lifetime>
+				<wst13:RequestedAttachedReference>
+					<wsse:SecurityTokenReference wsse11:TokenType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd">
+						<wsse:KeyIdentifier ValueType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.0#SAMLAssertionID">OaAodEmXNi7e-tYhxTRKUH4RaPl</wsse:KeyIdentifier>
+					</wsse:SecurityTokenReference>
+				</wst13:RequestedAttachedReference>
+				<wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+					<add:EndpointReference xmlns:add="http://www.w3.org/2005/08/addressing">
+						<add:Address>urn:federation:MicrosoftOnline</add:Address>
+					</add:EndpointReference>
+				</wsp:AppliesTo>
+			</wst13:RequestSecurityTokenResponse>
+		</wst13:RequestSecurityTokenResponseCollection>
+	</s:Body>
+</s:Envelope>


### PR DESCRIPTION
`AuthenticationContext.acquireTokenWithUsernamePassword` terminates with the following message:

```
TokenRequest: ERROR: RSTR returned unknown token type: http://docs.oasis-open.org/wss/oasis-  wss-saml-token-profile-1.1#SAMLV1.1
Stack:
Error: RSTR returned unknown token type: http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1
```

This is the WSTrustResponse snippet:

```
<s:Body>
        <wst13:RequestSecurityTokenResponseCollection xmlns:wst13="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
            <wst13:RequestSecurityTokenResponse>
                <wst13:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV1.1</wst13:TokenType>
                    <wst13:RequestedSecurityToken>
                        <saml:Assertion AssertionID="CONTENTS REDACTED" IssueInstant="2016-07-02T03:10:00.440Z" Issuer="CONTENTS REDACTED" MajorVersion="1" MinorVersion="1" xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion">
...
```

Please shower some review love on this, thank you!
