### PR TITLE
Removing antiquated brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Windows Azure Active Directory Authentication Library (ADAL) for Node.js
+# Azure Active Directory Authentication Library (ADAL) for Node.js
 The ADAL for node.js library makes it easy for node.js applications to authenticate to AAD in order to access AAD protected web resources.  It supports 3 authentication modes shown in the quickstart code below.
 
 ## Samples and Documentation

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/AzureAD/azure-activedirectory-library-for-nodejs.git"
   },
   "version": "0.1.21",
-  "description": "Windows Azure Active Directory Client Library for node",
+  "description": "Azure Active Directory Client Library for node",
   "keywords": [ "node", "azure", "AAD", "adal", "adfs", "oauth" ],
   "main": "./lib/adal.js",
   "engines": { "node": ">= 0.6.15" },


### PR DESCRIPTION
Hi,
This change removes 'Windows Azure' in the README and `package.json` files, so the brand becomes just Azure Active Directory.

Decided not to update/remove OpenTech branding now since I think that may be more involved.

Super nit.
