### PR TITLE
trim developer provided authority for endpoints

### DIFF
--- a/lib/authority.js
+++ b/lib/authority.js
@@ -227,11 +227,11 @@ Authority.prototype._getOAuthEndpoints = function(tenantDiscoveryEndpoint, callb
   } else {
     // fallback to the well known token endpoint path.
     if (!this._tokenEndpoint){
-       this._tokenEndpoint = url.format(this._url) + AADConstants.TOKEN_ENDPOINT_PATH;
+       this._tokenEndpoint = url.format('https://' + this._url.host + '/' + this._tenant) + AADConstants.TOKEN_ENDPOINT_PATH;
     }
 
     if (!this._deviceCodeEndpoint){
-       this._deviceCodeEndpoint = url.format(this._url) + AADConstants.DEVICE_ENDPOINT_PATH;
+       this._deviceCodeEndpoint = url.format('https://' + this._url.host + '/' + this._tenant) + AADConstants.DEVICE_ENDPOINT_PATH;
     }
 
     callback();

--- a/test/authority.js
+++ b/test/authority.js
@@ -252,6 +252,9 @@ suite('Authority', function() {
       if (err) {
         assert(!err, 'Received unexpected error: ' + err.stack);
       }
+
+      assert(authority.tokenEndpoint === (nonHardCodedAuthority + cp.tokenPath), "oauth2 token endpoint should be after tenant in the url");
+      assert(authority.deviceCodeEndpoint === (nonHardCodedAuthority + cp.deviceCodePath), "oauth2 device endpoint should be after tenant in the url");
       instanceDiscoveryRequest.done();
       done();
     });


### PR DESCRIPTION
Trim developer provided authority to construct endpoints so that they
resolve correctly. For example a developer may pass
https://contoso.com/adfs/ls/my-application, but the actual oauth2
endpoint would be https://contoso.com/adfs/oauth2/token instead of
https://contoso.com/adfs/ls/my-application/oauth2/token. #132