### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var _ = require('underscore');
-var uuid = require('node-uuid');  // want to replace with this in the future: https://gist.github.com/jed/982883
+var uuid = require('uuid');  // want to replace with this in the future: https://gist.github.com/jed/982883
 
 
 

--- a/lib/oauth2client.js
+++ b/lib/oauth2client.js
@@ -23,7 +23,7 @@
 var _ = require('underscore');
 require('date-utils');  // Adds a number of convenience methods to the builtin Date object.
 var querystring = require('querystring');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var request = require('request');
 var url = require('url');
 var async = require('async');

--- a/lib/self-signed-jwt.js
+++ b/lib/self-signed-jwt.js
@@ -26,7 +26,7 @@ var util = require('./util');
 
 require('date-utils');
 var jws = require('jws');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 /**
  * JavaScript dates are in milliseconds, but JWT dates are in seconds.

--- a/lib/wstrust-request.js
+++ b/lib/wstrust-request.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var request = require('request');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var Logger = require('./log').Logger;
 var util = require('./util');

--- a/package.json
+++ b/package.json
@@ -17,18 +17,27 @@
   },
   "version": "0.1.22",
   "description": "Windows Azure Active Directory Client Library for node",
-  "keywords": [ "node", "azure", "AAD", "adal", "adfs", "oauth" ],
+  "keywords": [
+    "node",
+    "azure",
+    "AAD",
+    "adal",
+    "adfs",
+    "oauth"
+  ],
   "main": "./lib/adal.js",
-  "engines": { "node": ">= 0.6.15" },
+  "engines": {
+    "node": ">= 0.6.15"
+  },
   "dependencies": {
+    "async": ">=0.6.0",
     "date-utils": "*",
     "jws": "3.x.x",
-    "node-uuid": "1.4.7",
     "request": ">= 2.52.0",
     "underscore": ">= 1.3.1",
+    "uuid": "^3.0.0",
     "xmldom": ">= 0.1.x",
-    "xpath.js": "~1.0.5", 
-    "async": ">=0.6.0"
+    "xpath.js": "~1.0.5"
   },
   "devDependencies": {
     "jshint": "*",
@@ -38,7 +47,7 @@
   },
   "scripts": {
     "test": "mocha -R spec --ui tdd test",
-    "cover" : "./test/util/cover",
-    "doc" : "jsdoc lib"
+    "cover": "./test/util/cover",
+    "doc": "jsdoc lib"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.