### PR TITLE
remove need for dynamic access to package.json to obtain lib version

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,6 @@
 
 var _ = require('underscore');
 var adalIdConstants = require('./constants').AdalIdParameters;
-var fs = require('fs');
 var os = require('os');
 var url = require('url');
 
@@ -34,9 +33,7 @@ var ADAL_VERSION;
  */
 
 function loadAdalVersion() {
-  var packageData = fs.readFileSync(__dirname + '/../package.json');
-  var packageJson = JSON.parse(packageData);
-  ADAL_VERSION = packageJson.version;
+  ADAL_VERSION = require('../package.json').version;
 }
 
 function adalInit() {


### PR DESCRIPTION
This PR fixes https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/155