### PR TITLE
apiVersion bug fixed with '1.0' compatibility

### DIFF
--- a/lib/authentication-context.js
+++ b/lib/authentication-context.js
@@ -86,10 +86,11 @@ var globalCache = new MemoryCache();
  *                                       construction of other AuthenticationContexts.
  *
  */
-function AuthenticationContext(authority, validateAuthority, cache) {
+function AuthenticationContext(authority, validateAuthority, cache, aadApiVersion) {
   var validate = (validateAuthority === undefined || validateAuthority === null || validateAuthority);
 
   this._authority = new Authority(authority, validate);
+  this._authority.aadApiVersion = aadApiVersion;
   this._oauth2client = null;
   this._correlationId = null;
   this._callContext = { options : globalADALOptions };

--- a/lib/oauth2client.js
+++ b/lib/oauth2client.js
@@ -70,6 +70,7 @@ DEVICE_CODE_RESPONSE_MAP[DeviceCodeResponseParameters.ERROR_DESCRIPTION] = UserC
  * @param {string|url} authority  An url that points to an authority.
  */
 function OAuth2Client(callContext, authority) {
+  this._aadApiVersion = authority.aadApiVersion === undefined? '1.0' : authority.aadApiVersion;
   this._tokenEndpoint = authority.tokenEndpoint;
   this._deviceCodeEndpoint = authority.deviceCodeEndpoint;
 
@@ -87,7 +88,7 @@ OAuth2Client.prototype._createTokenUrl = function () {
   var tokenUrl = url.parse(this._tokenEndpoint);
 
   var parameters = {};
-  parameters[OAuth2Parameters.AAD_API_VERSION] = '1.0';
+  parameters[OAuth2Parameters.AAD_API_VERSION] = this._aadApiVersion;
 
   tokenUrl.search = querystring.stringify(parameters);
   return tokenUrl;
@@ -102,7 +103,7 @@ OAuth2Client.prototype._createDeviceCodeUrl = function () {
    var deviceCodeUrl = url.parse(this._deviceCodeEndpoint);
 
    var parameters = {};
-   parameters[OAuth2Parameters.AAD_API_VERSION] = '1.0';
+   parameters[OAuth2Parameters.AAD_API_VERSION] = this._aadApiVersion;
 
    deviceCodeUrl.search = querystring.stringify(parameters);
 


### PR DESCRIPTION
fix this very common bug with fallback on "1.0" for compatibility.

usage: 

var context = new AuthenticationContext(authorityUrl,true,null,null);

or

var context = new AuthenticationContext(authorityUrl,true,null,'');
