### PR TITLE
Update xpath.js dependency to latest release. Fixes #185

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,9 +1015,9 @@
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xpath.js": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.0.7.tgz",
-      "integrity": "sha1-fpRif1QSdsvGprArXTXpQYVls+Q="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "request": ">= 2.52.0",
     "underscore": ">= 1.3.1",
     "xmldom": ">= 0.1.x",
-    "xpath.js": "~1.0.5",
+    "xpath.js": "~1.1.0",
     "async": ">=0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the reference to xpath.js to pull in the latest drop, version 1.1.0.