### PR TITLE
Removed the ErrorResponse type

### DIFF
--- a/lib/adal.d.ts
+++ b/lib/adal.d.ts
@@ -151,7 +151,7 @@ export interface ErrorResponse {
  * @param {Error}  [error]           If the request fails this parameter will contain an Error object.
  * @param {TokenResponse|ErrorResponse} [response]   On a succesful request returns a {@link TokenResposne}.
  */
-export type AcquireTokenCallback = (error: Error, response: TokenResponse | ErrorResponse) => void;
+export type AcquireTokenCallback = (error: Error, response: TokenResponse) => void;
 
 /**
  * This is the callback that is passed to all acquireUserCode method below.


### PR DESCRIPTION
I removed the `ErrorResponse` Type for the response argument in the `AcquireTokenCallback` function.
Before removing it, I was getting the error (red underlined) on compilation, as in the following screenshot:
![before_removing_errorresponse](https://user-images.githubusercontent.com/22086161/38147719-1db14ac0-3471-11e8-9ecf-1ca4dc3989a2.png)

And after I remove it, the error was resolved. 
