### PR TITLE
Fix exception of getting the length of undefined.

### DIFF
--- a/lib/cache-driver.js
+++ b/lib/cache-driver.js
@@ -159,7 +159,9 @@ CacheDriver.prototype._getPotentialEntries = function(query, callback) {
   this._log.verbose('Looking for potential cache entries:');
   this._log.verbose(JSON.stringify(potentialEntriesQuery), true);
   this._find(potentialEntriesQuery, function(err, entries) {
-    self._log.verbose('Found ' + entries.length + ' potential entries.');
+    if (entries) {
+      self._log.verbose('Found ' + entries.length + ' potential entries.');
+    }
     callback(err, entries);
     return;
   });

--- a/lib/cache-driver.js
+++ b/lib/cache-driver.js
@@ -522,3 +522,4 @@ CacheDriver.prototype.add = function(entry, callback) {
 };
 
 module.exports = CacheDriver;
+


### PR DESCRIPTION
Fixes `System.Exception : TypeError: Cannot read property 'length' of undefined` which happens when `CacheDriver._find()` returns an error and `entries` is `undefined`.