### PR TITLE
Update authority.js

### DIFF
--- a/lib/authority.js
+++ b/lib/authority.js
@@ -109,7 +109,12 @@ Authority.prototype._parseAuthority = function() {
   this._host = this._url.host;
 
   var pathParts = this._url.pathname.split('/');
-  this._tenant = pathParts[1];
+  for(var i = 1; i < pathParts.length; i++){
+		if(pathParts[i].length != 0){
+			this._tenant = pathParts[i];
+			break;
+		}
+	}
 
   if (!this._tenant) {
     throw new Error('Could not determine tenant.');


### PR DESCRIPTION
Cover cases when tenant is not at the first position at "pathParts" when split.
Sample: this._url.pathname = //contoso.com
Split Result: { "","","contoso.com"}