### PR TITLE
Fix bug in aquireTokenWithRefreshToken. Add optional OAuth ClientSecret to Token w/ Username and Password flow.

### DIFF
--- a/lib/adal.d.ts
+++ b/lib/adal.d.ts
@@ -293,9 +293,13 @@ export class AuthenticationContext {
    * @param {string}   username                            The username of the user on behalf this application is authenticating.
    * @param {string}   password                            The password of the user named in the username parameter.
    * @param {string}   clientId                            The OAuth client id of the calling application.
+   * @param {string}   [clientSecret]                      The OAuth client secret of the calling application. (Note: this parameter is a late addition.
+   *                                                        This parameter may be ommitted entirely so that applications built before this change will continue
+   *                                                        to work unchanged.)
    * @param {AcquireTokenCallback}   callback              The callback function.
    */
   public acquireTokenWithUsernamePassword(resource: string, username: string, password: string, clientId: string, callback: AcquireTokenCallback): void;
+  public acquireTokenWithUsernamePassword(resource: string, username: string, password: string, clientId: string, clientSecret: string, callback: AcquireTokenCallback): void;
 
   /**
    * Gets a token for a given resource.

--- a/lib/authentication-context.js
+++ b/lib/authentication-context.js
@@ -204,17 +204,17 @@ AuthenticationContext.prototype._acquireToken = function(callback, tokenFunction
   });
 };
 
-AuthenticationContext.prototype._acquireUserCode = function (callback, codeFunction) { 
-    var self = this;
-    this._callContext._logContext = createLogContext(this.correlationId);
-    this._authority.validate(this._callContext, function (err) { 
-        if (err) { 
-            callback(err);
-            return;
-        } 
+AuthenticationContext.prototype._acquireUserCode = function (callback, codeFunction) {
+  var self = this;
+  this._callContext._logContext = createLogContext(this.correlationId);
+  this._authority.validate(this._callContext, function (err) {
+    if (err) {
+      callback(err);
+      return;
+    }
 
-        codeFunction.call(self);
-    });
+    codeFunction.call(self);
+  });
 };
 
 /**
@@ -246,23 +246,33 @@ AuthenticationContext.prototype.acquireToken = function(resource, userId, client
  * @param {string}   username                            The username of the user on behalf this application is authenticating.
  * @param {string}   password                            The password of the user named in the username parameter.
  * @param {string}   clientId                            The OAuth client id of the calling application.
+ * @param {string}   [clientSecret]                      The OAuth client secret of the calling application.
  * @param {AcquireTokenCallback}   callback              The callback function.
  */
-AuthenticationContext.prototype.acquireTokenWithUsernamePassword = function(resource, username, password, clientId, callback)  {
-  argument.validateCallbackType(callback);
+AuthenticationContext.prototype.acquireTokenWithUsernamePassword = function(resource, username, password, clientId, clientSecret, callback) {
+  // Fix up the arguments.  Older clients may pass fewer arguments as the clientSecret paramter did not always exist.
+  // The code needs to make adjustments for those clients.
+  var clientSecretPresent = (6 === arguments.length);
+  var actualClientSecret = clientSecretPresent ? clientSecret : null;
+  var actualCallback = clientSecretPresent ? callback : clientSecret;
+
+  argument.validateCallbackType(actualCallback);
   try {
     argument.validateStringParameter(resource, 'resource');
     argument.validateStringParameter(username, 'username');
     argument.validateStringParameter(password, 'password');
     argument.validateStringParameter(clientId, 'clientId');
+    if(clientSecretPresent){
+      argument.validateStringParameter(actualClientSecret, 'clientSecret');
+    }
   } catch(err) {
-    callback(err);
+    actualCallback(err);
     return;
   }
 
-  this._acquireToken(callback, function() {
+  this._acquireToken(actualCallback, function() {
     var tokenRequest = new TokenRequest(this._callContext, this, clientId, resource);
-    tokenRequest.getTokenWithUsernamePassword(username, password, callback);
+    tokenRequest.getTokenWithUsernamePassword(username, password, actualClientSecret, actualCallback);
   });
 };
 
@@ -332,19 +342,19 @@ AuthenticationContext.prototype.acquireTokenWithRefreshToken = function(refreshT
   // The code needs to make adjustments for those clients.
   var clientSecretPresent = (5 === arguments.length);
   var actualClientSecret = clientSecretPresent ? clientSecret : null;
-  var actualCallback = clientSecretPresent ? arguments[4] : arguments[3];
-  var actualResource = clientSecretPresent ? arguments[3] : arguments[2];
+  var actualCallback = clientSecretPresent ? callback : resource;
+  var actualResource = clientSecretPresent ? resource : clientSecret;
 
   argument.validateCallbackType(actualCallback);
   try {
     argument.validateStringParameter(refreshToken, 'refreshToken');
     argument.validateStringParameter(clientId, 'clientId');
   } catch(err) {
-    callback(err);
+    actualCallback(err);
     return;
   }
 
-  this._acquireToken(callback, function() {
+  this._acquireToken(actualCallback, function() {
     var tokenRequest = new TokenRequest(this._callContext, this, clientId, actualResource);
     tokenRequest.getTokenWithRefreshToken(refreshToken, actualClientSecret, actualCallback);
   });
@@ -382,21 +392,21 @@ AuthenticationContext.prototype.acquireTokenWithClientCertificate = function(res
  * @param  {string}   language                            The language code specifying how the message should be localized to. 
  * @param  {AcquireTokenCallback}   callback              The callback function.
  */
-AuthenticationContext.prototype.acquireUserCode = function(resource, clientId, language, callback) { 
-    argument.validateCallbackType(callback);
-    
-    try { 
-        argument.validateStringParameter(resource, 'resource');
-        argument.validateStringParameter(clientId, 'clientId');
-    } catch (err) { 
-        callback(err);
-        return;
-    }    
+AuthenticationContext.prototype.acquireUserCode = function(resource, clientId, language, callback) {
+  argument.validateCallbackType(callback);
 
-    this._acquireUserCode(callback, function () { 
-        var codeRequest = new CodeRequest(this._callContext, this, clientId, resource);
-        codeRequest.getUserCodeInfo(language, callback);   
-    });
+  try {
+    argument.validateStringParameter(resource, 'resource');
+    argument.validateStringParameter(clientId, 'clientId');
+  } catch (err) {
+    callback(err);
+    return;
+  }
+
+  this._acquireUserCode(callback, function () {
+    var codeRequest = new CodeRequest(this._callContext, this, clientId, resource);
+    codeRequest.getUserCodeInfo(language, callback);
+  });
 };
 
 /**
@@ -408,21 +418,23 @@ AuthenticationContext.prototype.acquireUserCode = function(resource, clientId, l
  * @param  {AcquireTokenCallback}   callback              The callback function.
  */
 AuthenticationContext.prototype.acquireTokenWithDeviceCode = function(resource, clientId, userCodeInfo, callback){
-    argument.validateCallbackType(callback);
+  argument.validateCallbackType(callback);
 
-    try{
-       argument.validateUserCodeInfo(userCodeInfo);
-    } catch (err) {
-       callback(err);
-       return;
-    }
+  try{
+    argument.validateStringParameter(resource, 'resource');
+    argument.validateStringParameter(clientId, 'clientId');
+    argument.validateUserCodeInfo(userCodeInfo);
+  } catch (err) {
+    callback(err);
+    return;
+  }
 
-    var self = this;
-    this._acquireToken(callback, function() {
-        var tokenRequest = new TokenRequest(this._callContext, this, clientId, resource, null);
-        self._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]] = tokenRequest;
-        tokenRequest.getTokenWithDeviceCode(userCodeInfo, callback); 
-    })
+  var self = this;
+  this._acquireToken(callback, function() {
+    var tokenRequest = new TokenRequest(this._callContext, this, clientId, resource, null);
+    self._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]] = tokenRequest;
+    tokenRequest.getTokenWithDeviceCode(userCodeInfo, callback);
+  })
 };
 
 /**
@@ -431,24 +443,24 @@ AuthenticationContext.prototype.acquireTokenWithDeviceCode = function(resource, 
  * @param  {AcquireTokenCallback}   callback              The callback function.
  */
 AuthenticationContext.prototype.cancelRequestToGetTokenWithDeviceCode = function (userCodeInfo, callback) {
-    argument.validateCallbackType(callback);
+  argument.validateCallbackType(callback);
 
-    try {
-       argument.validateUserCodeInfo(userCodeInfo);
-    } catch (err) {
-       callback(err);
-       return;
-    }
+  try {
+    argument.validateUserCodeInfo(userCodeInfo);
+  } catch (err) {
+    callback(err);
+    return;
+  }
 
-    if (!this._tokenRequestWithUserCode || !this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]]) {
-       callback(new Error('No acquireTokenWithDeviceCodeRequest existed to be cancelled')); 
-       return;
-    }
+  if (!this._tokenRequestWithUserCode || !this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]]) {
+    callback(new Error('No acquireTokenWithDeviceCodeRequest existed to be cancelled'));
+    return;
+  }
 
-    var tokenRequestToBeCancelled = this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]];
-    tokenRequestToBeCancelled.cancelTokenRequestWithDeviceCode();
+  var tokenRequestToBeCancelled = this._tokenRequestWithUserCode[userCodeInfo[constants.UserCodeResponseFields.DEVICE_CODE]];
+  tokenRequestToBeCancelled.cancelTokenRequestWithDeviceCode();
 
-    delete this._tokenRequestWithUserCode[constants.UserCodeResponseFields.DEVICE_CODE];
+  delete this._tokenRequestWithUserCode[constants.UserCodeResponseFields.DEVICE_CODE];
 };
 
 var exports = {

--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -60,6 +60,10 @@ function TokenRequest(callContext, authenticationContext, clientId, resource, re
   // functions that have a userId.
   this._userId = null;
 
+  // This should be set at the beginning of getToken
+  // functions that have a need to pass the OAuth clientSecret
+  this._clientSecret = null;
+
   this._userRealm = null;
   this._pollingClient = {};
 }
@@ -185,7 +189,7 @@ TokenRequest.prototype._addTokenIntoCache = function(tokenResponse, callback) {
  * @param {object} value
  */
 function _addParameterIfAvailable(parameters, key, value) {
-  if (value) {
+  if (parameters && key && value) {
     parameters[key] = value;
   }
 }
@@ -208,6 +212,7 @@ TokenRequest.prototype._createOAuthParameters = function(grantType) {
   }
 
   _addParameterIfAvailable(oauthParameters, OAuth2Parameters.CLIENT_ID, this._clientId);
+  _addParameterIfAvailable(oauthParameters, OAuth2Parameters.CLIENT_SECRET, this._clientSecret);
   _addParameterIfAvailable(oauthParameters, OAuth2Parameters.RESOURCE, this._resource);
   _addParameterIfAvailable(oauthParameters, OAuth2Parameters.REDIRECT_URI, this._redirectUri);
 
@@ -403,13 +408,20 @@ TokenRequest.prototype._parseWStrustVersionFromFederationActiveAuthUrl = functio
  * @private
  * @param  {string}   username
  * @param  {string}   password
+ * @param  {string}   [clientSecret]
  * @param  {AcquireTokenCallback} callback
  */
-TokenRequest.prototype.getTokenWithUsernamePassword = function(username, password, callback) {
+TokenRequest.prototype.getTokenWithUsernamePassword = function(username, password, clientSecret, callback) {
   this._log.info('Acquiring token with username password');
   this._userId = username;
-
-  this._getTokenWithCacheWrapper(callback, function(getTokenCompleteCallback) {
+  // Fix up the arguments.  Older clients may pass fewer arguments as the clientSecret paramter did not always exist.
+  // The code needs to make adjustments for those clients.
+  const clientSecretPresent = (4 === arguments.length);
+  const actualCallback = clientSecretPresent ? callback : clientSecret;  
+  // Set the OAuth client's client secret if provided.
+  this._clientSecret = clientSecretPresent ? clientSecret : null;
+  
+  this._getTokenWithCacheWrapper(actualCallback, function(getTokenCompleteCallback) {
     var self = this;
 
       if(this._authenticationContext._authority._isAdfsAuthority) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adal-node",
-  "version": "0.1.22",
+  "version": "0.1.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12,6 +12,38 @@
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "@types/nock": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-8.2.1.tgz",
+      "integrity": "sha1-H75b3suUPBCad4VT+k0kAcuTlLQ=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "8.10.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
+      "integrity": "sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg=="
+    },
+    "@types/sinon": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.7.tgz",
+      "integrity": "sha512-w+LjztaZbgZWgt/y/VMP5BUAWLtSyoIJhXyW279hehLPyubDoBNwvhcj3WaSptcekuKYeTCVxrq60rdLc6ImJA==",
+      "dev": true
+    },
+    "@types/underscore": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.8.tgz",
+      "integrity": "sha512-EquzRwzAAs04anQ8/6MYXFKvHoD+MIlF+gu87EDda7dN9zrKvQYHsc9VFAPB1xY4tUHQVvBMtjsHrvof2EE1Mg==",
+      "dev": true
     },
     "ajv": {
       "version": "5.5.2",
@@ -657,11 +689,6 @@
         "semver": "^5.5.0"
       }
     },
-    "node-uuid": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
-    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -878,10 +905,21 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
+    },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "uuid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.0.tgz",
+      "integrity": "sha512-ijO9N2xY/YaOqQ5yz5c4sy2ZjWmA6AR6zASb/gdpeKZ8+948CxwfMW9RrKVk5may6ev8c0/Xguu32e2Llelpqw=="
     },
     "verror": {
       "version": "1.10.0",
@@ -905,9 +943,9 @@
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xpath.js": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.0.7.tgz",
-      "integrity": "sha1-fpRif1QSdsvGprArXTXpQYVls+Q="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     }
   }
 }


### PR DESCRIPTION
- Fix to `aquireTokenWithRefreshToken` not using the correct `actualCallback` when using old signature.
- Change `arguments` ordinal access to clear up what arguments are being used in `aquireTokenWithRefreshToken`
- Add `clientSecret` as optional parameter to the `aquireTokenWithUsernamePassword` - used same style of backwards compatibility used for `aquireTokenWithRefreshToken`
- Ensure that unit tests related to changes are in a passing state (master seems to have a failing test checked-in for device-code test of `bad-argument`)

Adds the functionality missing/requested in this issue. https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/issues/152