### PR TITLE
Allow non-https auth endpoints

### DIFF
--- a/lib/authority.js
+++ b/lib/authority.js
@@ -39,7 +39,9 @@ var util = require('./util');
 function Authority(authorityUrl, validateAuthority) {
   this._log = null;
   this._url = url.parse(authorityUrl);
-  this._validateAuthorityUrl();
+  if (validateAuthority) {
+    this._validateAuthorityUrl();
+  }
 
   this._validated = !validateAuthority;
   this._host = null;
@@ -228,11 +230,11 @@ Authority.prototype._getOAuthEndpoints = function(tenantDiscoveryEndpoint, callb
   } else {
     // fallback to the well known token endpoint path.
     if (!this._tokenEndpoint){
-       this._tokenEndpoint = url.format('https://' + this._url.host + '/' + encodeURIComponent(this._tenant)) + AADConstants.TOKEN_ENDPOINT_PATH;
+       this._tokenEndpoint = url.format(this._url.protocol + '//' + this._url.host + '/' + encodeURIComponent(this._tenant)) + AADConstants.TOKEN_ENDPOINT_PATH;
     }
 
     if (!this._deviceCodeEndpoint){
-       this._deviceCodeEndpoint = url.format('https://' + this._url.host + '/' + encodeURIComponent(this._tenant)) + AADConstants.DEVICE_ENDPOINT_PATH;
+       this._deviceCodeEndpoint = url.format(this._url.protocol + '//' + this._url.host + '/' + encodeURIComponent(this._tenant)) + AADConstants.DEVICE_ENDPOINT_PATH;
     }
 
     callback();


### PR DESCRIPTION
This is useful when integrating with stubs for testing.