### PR TITLE
Update supported Node.js version in `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./lib/adal.js",
   "types": "./lib/adal.d.ts",
   "engines": {
-    "node": ">= 0.6.15"
+    "node": ">= 6"
   },
   "dependencies": {
     "@types/node": "^8.0.47",


### PR DESCRIPTION
`package.json` currently specifies that this package is compatible with Node.js `0.6.15` and newer. That is not really correct, as many of the dependencies used by this library require newer Node.js versions, and will fail to load on older versions.

The oldest supported version by all non-development dependencies is 6.x, so that's also what this library should have as it's oldest supported version.