### PR TITLE
Converting token expiry date from string to Date when calling 'date-utils' isAfter()

### DIFF
--- a/lib/cache-driver.js
+++ b/lib/cache-driver.js
@@ -328,7 +328,7 @@ CacheDriver.prototype._refreshEntryIfNecessary = function(entry, isResourceSpeci
   // Add some buffer in to the time comparison to account for clock skew or latency.
   var nowPlusBuffer = (new Date()).addMinutes(constants.Misc.CLOCK_BUFFER);
 
-  if (isResourceSpecific && nowPlusBuffer.isAfter(expiryDate)) {
+  if (isResourceSpecific && nowPlusBuffer.isAfter(Date.parse(expiryDate))) {
     this._log.info('Cached token is expired.  Refreshing: ' + expiryDate);
     this._refreshExpiredEntry(entry, callback);
     return;


### PR DESCRIPTION
During long-running operations, AuthenticationContext.acquireToken eventually starts returning expired access tokens. 

The reason is that CacheDriver utilizes `isAfter()` function defined in `date-utils, `passing string value from `entry[TokenResponseFields.EXPIRES_ON]` - which is not handled properly, so that `isAfter()` always returns `false`. Basically, Date is compared to string.

Converting string value from `entry[TokenResponseFields.EXPIRES_ON]` to `Date` fixes the issue.