### PR TITLE
Add correlation_id logging to axios requests

### DIFF
--- a/lib/authentication-parameters.js
+++ b/lib/authentication-parameters.js
@@ -239,8 +239,8 @@ exports.createAuthenticationParametersFromUrl = function(url, callback, correlat
     logger.verbose('Attempting to retrieve authentication parameters from: ' + challengeUrl, true);
     var options = util.createRequestOptions({ _callContext: { _logContext: logContext } });
     
-    // TODO: Check if this is alright
     axios.get(challengeUrl, options).then((response) => {
+      util.logReturnCorrelationId(logger, "Authentication Parameters", response);
       var parameters;
       try {
         parameters = exports.createAuthenticationParametersFromResponse(response);
@@ -251,8 +251,9 @@ exports.createAuthenticationParametersFromUrl = function(url, callback, correlat
       callback(null, parameters);
     }).catch((error) => {
       // status >= 400: error case
-      if (error.response) {
+      if (error.response) {        
         var parameters;
+        util.logReturnCorrelationId(logger, "Authentication Parameters", error.response);
         try {
           parameters = exports.createAuthenticationParametersFromResponse(error.response);
         } catch (creationErr) {

--- a/lib/authority.js
+++ b/lib/authority.js
@@ -170,6 +170,7 @@ Authority.prototype._performDynamicInstanceDiscovery = function(callback) {
     this._log.verbose('Attempting instance discover at: ' + url.format(discoveryEndpoint), true);
 
     axios.get(discoveryEndpoint, getOptions).then((response) => {
+      util.logReturnCorrelationId(this._log, 'Instance Discovery', response);
       // status >= 300 && < 400
       if (!util.isHttpSuccess(response.status)) {
         var returnErrorString = 'Instance Discovery' + ' request returned http error: ' + response.status + ' and server response: ' + JSON.stringify(error.response.data);
@@ -185,6 +186,7 @@ Authority.prototype._performDynamicInstanceDiscovery = function(callback) {
     }).catch((error) => {
       // status >= 400: error case
       if (error.response) {
+        util.logReturnCorrelationId(this._log, 'Instance Discovery', error.response);
         this._log.error('Instance Discovery' + ' request failed with', error.response.status, true);
         var returnErrorString = 'Instance Discovery' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);
         callback(self._log.createError(returnErrorString, true), error.response.data);

--- a/lib/mex.js
+++ b/lib/mex.js
@@ -81,7 +81,7 @@ Mex.prototype.discover = function (callback) {
   var self = this;
   var options = util.createRequestOptions(self, { headers: { 'Content-Type': 'application/soap+xml' } });
   axios.get(this._url, options).then((response) => {
-    util.logReturnCorrelationId(this._log, "Mex Get", response);
+    util.logReturnCorrelationId(this._log, 'Mex Get', response);
 
     // status >= 300 && < 400
     if (!util.isHttpSuccess(response.status)) {
@@ -106,7 +106,7 @@ Mex.prototype.discover = function (callback) {
     // status >= 400: error case
     if (error.response) {
       this._log.error('Mex Get' + ' request failed with', error.response.status, true);
-      util.logReturnCorrelationId(this._log, "Mex Get", error.response);
+      util.logReturnCorrelationId(this._log, 'Mex Get', error.response);
       var returnErrorString = 'Mex Get' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);;
       callback(self._log.createError(returnErrorString, true), error.response.data);
     }

--- a/lib/mex.js
+++ b/lib/mex.js
@@ -81,6 +81,8 @@ Mex.prototype.discover = function (callback) {
   var self = this;
   var options = util.createRequestOptions(self, { headers: { 'Content-Type': 'application/soap+xml' } });
   axios.get(this._url, options).then((response) => {
+    util.logReturnCorrelationId(this._log, "Mex Get", response);
+
     // status >= 300 && < 400
     if (!util.isHttpSuccess(response.status)) {
       var returnErrorString = 'Mex Get' + ' request returned http error: ' + response.status + ' and server response: ' + response.status;;
@@ -104,6 +106,7 @@ Mex.prototype.discover = function (callback) {
     // status >= 400: error case
     if (error.response) {
       this._log.error('Mex Get' + ' request failed with', error.response.status, true);
+      util.logReturnCorrelationId(this._log, "Mex Get", error.response);
       var returnErrorString = 'Mex Get' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);;
       callback(self._log.createError(returnErrorString, true), error.response.data);
     }

--- a/lib/oauth2client.js
+++ b/lib/oauth2client.js
@@ -410,6 +410,7 @@ OAuth2Client.prototype._getTokenWithPolling = function (postOptions, callback) {
 
     axios(postOptions).then((response) => {
       var tokenResponse;
+      util.logReturnCorrelationId(this._log, 'GetToken', response);
       try {
         tokenResponse = self._handlePollingResponse(response.data);
       } catch (e) {
@@ -421,6 +422,7 @@ OAuth2Client.prototype._getTokenWithPolling = function (postOptions, callback) {
     }).catch((error) => {
       // status >= 400: error case
       if (error.response) {
+        util.logReturnCorrelationId(this._log, 'GetToken', error.response);
         // error response callback, for error response, it's already parsed as Json. 
         if (error.response && error.response.data.hasOwnProperty(TokenResponseFields.ERROR) && error.response.data[TokenResponseFields.ERROR] === 'authorization_pending') {
           callback(new Error(error.response.data[TokenResponseFields.ERROR]), error.response.data);
@@ -483,6 +485,7 @@ OAuth2Client.prototype.getToken = function(oauthParameters, callback) {
   var postOptions = self._createPostOption(tokenUrl, urlEncodedTokenRequestForm);
 
   axios(postOptions).then((response) => {
+    util.logReturnCorrelationId(this._log, 'Get Token', response);
     // status >= 300 && < 400
     if (!util.isHttpSuccess(response.status)) {
       var returnErrorString = 'Get Token' + ' request returned http error: ' + response.status + ' and server response: ' + JSON.stringify(error.response.data);
@@ -493,6 +496,7 @@ OAuth2Client.prototype.getToken = function(oauthParameters, callback) {
   }).catch((error) => {
     // status >= 400: error case
     if (error.response) {
+      util.logReturnCorrelationId(this._log, 'Get Token', error.response);
       this._log.error('Get Token' + ' request failed with', error.response.status, true);
       var returnErrorString = 'Get Token' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);
       callback(self._log.createError(returnErrorString, true), error.response.data);
@@ -557,6 +561,7 @@ OAuth2Client.prototype.getUserCodeInfo = function(oauthParameters, callback) {
     var postOptions = self._createPostOption(deviceCodeUrl, urlEncodedDeviceCodeRequestForm);
   
     axios(postOptions).then((response) => {
+      util.logReturnCorrelationId(this._log, 'Get Device Code', response);
       // status >= 300 && < 400
       if (!util.isHttpSuccess(response.status)) {
         var returnErrorString = 'Get Device Code' + ' request returned http error: ' + response.status + ' and server response: ' + JSON.stringify(error.response.data);
@@ -567,6 +572,7 @@ OAuth2Client.prototype.getUserCodeInfo = function(oauthParameters, callback) {
     }).catch((error) => {
       // status >= 400: error case
       if (error.response) {
+      util.logReturnCorrelationId(this._log, 'Get Device Code', error.response);
         this._log.error('Get Device Code' + ' request failed with', error.response.status, true);
         var returnErrorString = 'Get Device Code' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);
         callback(self._log.createError(returnErrorString, true), error.response.data);

--- a/lib/user-realm.js
+++ b/lib/user-realm.js
@@ -260,6 +260,7 @@ UserRealm.prototype.discover = function(callback) {
   this._log.verbose('Performing user realm discovery at: ' + url.format(userRealmUrl), true);
 
   axios.get(userRealmUrl, options).then((response) => {
+    util.logReturnCorrelationId(this._log, 'User Realm Discovery', response);
     // status >= 300 && < 400
     if (!util.isHttpSuccess(response.status)) {
       var returnErrorString = 'User Realm Discovery' + ' request returned http error: ' + response.status + ' and server response: ' + response.status;
@@ -270,6 +271,7 @@ UserRealm.prototype.discover = function(callback) {
   }).catch((error) => {
     // status >= 400: error case
     if (error.response) {
+      util.logReturnCorrelationId(this._log, 'User Realm Discovery', error.response);
       this._log.error('User Realm Discovery' + ' request failed with', error.response.status, true);
       var returnErrorString = 'User Realm Discovery' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);
       callback(this._log.createError(returnErrorString, true), error.response.data);

--- a/lib/util.js
+++ b/lib/util.js
@@ -180,6 +180,7 @@ function base64EncodeStringUrlSafe(str) {
 
 module.exports.adalInit = adalInit;
 module.exports.isHttpSuccess = isHttpSuccess;
+module.exports.logReturnCorrelationId = logReturnCorrelationId;
 module.exports.createRequestHandler = createRequestHandler;
 module.exports.createRequestOptions = createRequestOptions;
 module.exports.copyUrl = copyUrl;

--- a/lib/wstrust-request.js
+++ b/lib/wstrust-request.js
@@ -228,6 +228,7 @@ WSTrustRequest.prototype.acquireToken = function(username, password, callback) {
   this._log.verbose('Sending RST to: ' + this._wstrustEndpointUrl, true);
 
   axios(options).then((response) => {
+    util.logReturnCorrelationId(this._log, 'WS-Trust RST', response);
     // status >= 300 && < 400
     if (!util.isHttpSuccess(response.status)) {
       var returnErrorString = 'WS-Trust RST' + ' request returned http error: ' + response.status + ' and server response: ' + JSON.stringify(error.response.data);
@@ -238,6 +239,7 @@ WSTrustRequest.prototype.acquireToken = function(username, password, callback) {
   }).catch((error) => {
     // status >= 400: error case
     if (error.response) {
+      util.logReturnCorrelationId(this._log, 'WS-Trust RST', error.response);
       this._log.error('WS-Trust RST' + ' request failed with', error.response.status, true);
       var returnErrorString = 'WS-Trust RST' + ' request returned http error: ' + error.response.status + ' and server response: ' + JSON.stringify(error.response.data);
       callback(self._log.createError(returnErrorString, true), error.response.data);


### PR DESCRIPTION
This PR returns the log messages containing the server returned correlation ID that were removed when `request` was replaced by `axios`, fixing a broken test.